### PR TITLE
Add `from_sqlite`

### DIFF
--- a/faro/database.py
+++ b/faro/database.py
@@ -10,8 +10,8 @@ from pandas import (
 from .table import Table
 
 class Database:
-    def __init__(self, name : str):
-        self._conn = connect(':memory:')
+    def __init__(self, name : str, connection : str=':memory:'):
+        self._conn = connect(connection)
         self._cursor = self._conn.cursor()
         self._name = str(name)
         self._tables = []
@@ -23,6 +23,12 @@ class Database:
 
     def __repr__(self):
         return f'Database("{self._name}")'
+
+    @classmethod
+    def from_sqlite(cls, connection : str):
+        basename = os.path.basename(connection)
+        name, ext = os.path.splitext(basename)
+        return cls(name, connection=connection)
 
     def add_table(self, table, name, if_exists='fail', *args, **kwargs):
         """

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,4 +1,5 @@
 import os, pytest
+import sqlite3
 from numpy import ndarray
 from pandas import DataFrame
 
@@ -52,3 +53,56 @@ def test_export_sqlite():
 
     # cleanup
     os.remove(DB_PATH)
+
+def test_import_sqlite():
+    """Test loading a database from disk"""
+    path = os.path.join(TEST_PATH, 'disk_test.db')
+
+    sqlite3.connect(path)
+
+    db = faro.Database.from_sqlite(path)
+
+    table = faro.Table(data)
+    db.add_table(table, 'other_fruits')
+
+    os.remove(path)
+
+def test_import_sqlite_has_name():
+    """Test loading a database from disk"""
+    path = os.path.join(TEST_PATH, 'disk_test.db')
+
+    sqlite3.connect(path)
+
+    db = faro.Database.from_sqlite(path)
+
+    assert db.name == 'disk_test'
+
+    os.remove(path)
+
+def test_import_sqlite_no_extension_has_name():
+    """Test loading a database from disk"""
+    path = os.path.join(TEST_PATH, 'disk_test')
+
+    sqlite3.connect(path)
+
+    db = faro.Database.from_sqlite(path)
+
+    assert db.name == 'disk_test'
+
+    os.remove(path)
+
+def test_import_sqlite_has_path():
+    """Test loading a database from disk"""
+    directory = os.path.join(TEST_PATH, 'test')
+    os.makedirs(directory, exist_ok=True)
+
+    path = os.path.join(directory, 'disk_test.db')
+
+    sqlite3.connect(path)
+
+    db = faro.Database.from_sqlite(path)
+
+    assert db.name == 'disk_test'
+
+    os.remove(path)
+    os.rmdir(directory)


### PR DESCRIPTION
hi @yanniskatsaros! happy hacktoberfest 🎃

This addresses #3.

I've added `connection` as a new kwarg on the `Database` object, and used this to add a `.from_sqlite()` method that does some shuffling to get the name from the file name.

```python
Database("my_database", connection="my_database.db")

Database.from_sqlite("my_database.db")
```

The only thing I'm not sure about is with this implementation it leaves the database on disk. It doesn't create a new db in memory and copy the data across.

> With faro you can use pure SQL to work with a collection of table objects in memory

Should this apply for this use case as well? If so, I think it will tie in with #5.
